### PR TITLE
- Using xcode-select to identify real Xcode path

### DIFF
--- a/install.swift
+++ b/install.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 let templateName = "Module VIPER.xctemplate"
-let destinationPath = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Xcode/Templates/Project Templates/iOS/Application"
+let destinationRelativePath = "/Platforms/iPhoneOS.platform/Developer/Library/Xcode/Templates/Project Templates/iOS/Application"
 
 func printInConsole(_ message:Any){
     print("====================================")
@@ -20,7 +20,7 @@ func printInConsole(_ message:Any){
 func moveTemplate(){
 
     let fileManager = FileManager.default
-    
+    let destinationPath = bash(command: "xcode-select", arguments: ["--print-path"]).appending(destinationRelativePath)
     do {
         if !fileManager.fileExists(atPath:"\(destinationPath)/\(templateName)"){
         
@@ -37,8 +37,29 @@ func moveTemplate(){
     }
 }
 
+func shell(launchPath: String, arguments: [String]) -> String
+{
+    let task = Process()
+    task.launchPath = launchPath
+    task.arguments = arguments
+    
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    task.launch()
+    
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: String.Encoding.utf8)!
+    if output.characters.count > 0 {
+        //remove newline character.
+        let lastIndex = output.index(before: output.endIndex)
+        return output[output.startIndex ..< lastIndex]
+    }
+    return output
+}
+
+func bash(command: String, arguments: [String]) -> String {
+    let whichPathForCommand = shell(launchPath: "/bin/bash", arguments: [ "-l", "-c", "which \(command)" ])
+    return shell(launchPath: whichPathForCommand, arguments: arguments)
+}
+
 moveTemplate()
-
-
-
-


### PR DESCRIPTION
There is a problem with install.swift script - if you have Xcode installed in different folder than default or if you have multiple Xcode versions it either fails or installs templates in wrong Xcode version.

To fix this problem I suggest to use "xcode-select --print-path" command to get active Xcode path dynamically instead of hardcoded "/Applications/Xcode.app/Contents/Developer".
