### PR TITLE
Add method to create module in router

### DIFF
--- a/Module VIPER.xctemplate/___FILEBASENAME___Router.swift
+++ b/Module VIPER.xctemplate/___FILEBASENAME___Router.swift
@@ -11,5 +11,20 @@
 import UIKit
 
 class ___FILEBASENAMEASIDENTIFIER___Router: ___FILEBASENAMEASIDENTIFIER___WireframeProtocol {
-
+    
+    weak var viewController: UIViewController?
+    
+    static func createModule() -> UIViewController {
+        // Change to get view from storyboard if not using progammatic UI
+        let view = ___FILEBASENAMEASIDENTIFIER___ViewController()
+        let interactor = ___FILEBASENAMEASIDENTIFIER___Interactor()
+        let router = ___FILEBASENAMEASIDENTIFIER___Router()
+        let presenter = ___FILEBASENAMEASIDENTIFIER___Presenter(interface: view, interactor: interactor, router: router)
+        
+        view.presenter = presenter
+        interactor.presenter = presenter
+        router.viewController = view
+        
+        return view
+    }
 }

--- a/Module VIPER.xctemplate/___FILEBASENAME___Router.swift
+++ b/Module VIPER.xctemplate/___FILEBASENAME___Router.swift
@@ -16,7 +16,7 @@ class ___FILEBASENAMEASIDENTIFIER___Router: ___FILEBASENAMEASIDENTIFIER___Wirefr
     
     static func create___FILEBASENAMEASIDENTIFIER___Module() -> UIViewController {
         // Change to get view from storyboard if not using progammatic UI
-        let view = ___FILEBASENAMEASIDENTIFIER___ViewController()
+        let view = ___FILEBASENAMEASIDENTIFIER___ViewController(nibName: nil, bundle: nil)
         let interactor = ___FILEBASENAMEASIDENTIFIER___Interactor()
         let router = ___FILEBASENAMEASIDENTIFIER___Router()
         let presenter = ___FILEBASENAMEASIDENTIFIER___Presenter(interface: view, interactor: interactor, router: router)

--- a/Module VIPER.xctemplate/___FILEBASENAME___Router.swift
+++ b/Module VIPER.xctemplate/___FILEBASENAME___Router.swift
@@ -14,7 +14,7 @@ class ___FILEBASENAMEASIDENTIFIER___Router: ___FILEBASENAMEASIDENTIFIER___Wirefr
     
     weak var viewController: UIViewController?
     
-    static func createModule() -> UIViewController {
+    static func create___FILEBASENAMEASIDENTIFIER___Module() -> UIViewController {
         // Change to get view from storyboard if not using progammatic UI
         let view = ___FILEBASENAMEASIDENTIFIER___ViewController()
         let interactor = ___FILEBASENAMEASIDENTIFIER___Interactor()


### PR DESCRIPTION
- Added a create module method in the router that returns the next view controller
- This eliminates more redundant code that is necessary when creating new modules
- Makes it more clear how the entities interact with each other for someone new to viper